### PR TITLE
コンポーネントにスタイルを当てて、viteをインストール

### DIFF
--- a/04_react_basic/src/060_styling/start/Example.css
+++ b/04_react_basic/src/060_styling/start/Example.css
@@ -1,0 +1,5 @@
+.component {
+    padding:1rem;
+    color:red;
+    border: 5px solid red;
+}

--- a/04_react_basic/src/060_styling/start/Example.jsx
+++ b/04_react_basic/src/060_styling/start/Example.jsx
@@ -1,9 +1,8 @@
-/**
- * [注意]レクチャーをプルダウンで選択すると、<head>タグにそのレクチャーでimport "Example.css"のように読み込んだスタイルが挿入されます。このスタイルはプルダウンを切り替えても残りつづけるため、まだcssを記述していないのにスタイルが適用されていると感じた場合にはブラウザを更新してください。
- */
+import "./Example.css";
+
 const Example = () => {
   return (
-    <div>
+    <div className="component">
       <h3>Hello Component</h3>
     </div>
   );


### PR DESCRIPTION
- viteをインストール

viteがインストールされていなかった。
```
hashimotonoriaki@MacBook-Pro-3 start % npm start

> react-app-template@0.0.0 start
> vite

failed to load config from /Users/hashimotonoriaki/git/react-guide-material/04_react_basic/vite.config.js
error when starting dev server:
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'vite' imported from /Users/hashimotonoriaki/git/react-guide-material/04_react_basic/vite.config.js.timestamp-1714995694046-2ecd07afbceb1.mjs
   #中略
```
以下のコマンドで確認してからインストール。
```
npm ls vite   

npm install vite --save-dev

npm run dev 
```


<img width="717" alt="スクリーンショット 2024-05-06 20 49 20" src="https://github.com/Hashimoto-Noriaki/react-guide-training/assets/73786052/fd5c8568-a97a-4a6c-8e02-25292fe3faf7">

